### PR TITLE
fix: ignore trivial constraints like 0 * LC == 0 from circom

### DIFF
--- a/src/circom_circuit.rs
+++ b/src/circom_circuit.rs
@@ -120,12 +120,15 @@ impl<'a, E: Engine> Circuit<E> for CircomCircuit<E> {
                 })
         };
         for (i, constraint) in self.r1cs.constraints.iter().enumerate() {
-            cs.enforce(
-                || format!("constraint {}", i),
-                |_| make_lc(constraint.0.clone()),
-                |_| make_lc(constraint.1.clone()),
-                |_| make_lc(constraint.2.clone()),
-            );
+            // 0 * LC = 0 must be ignored
+            if !((constraint.0.is_empty() || constraint.1.is_empty()) && constraint.2.is_empty()) {
+                cs.enforce(
+                    || format!("constraint {}", i),
+                    |_| make_lc(constraint.0.clone()),
+                    |_| make_lc(constraint.1.clone()),
+                    |_| make_lc(constraint.2.clone()),
+                );
+            }
         }
         Ok(())
     }

--- a/src/plonk.rs
+++ b/src/plonk.rs
@@ -7,7 +7,7 @@ use bellman_ce::{
         better_cs::cs::PlonkCsWidth4WithNextStepParams,
         better_cs::keys::{Proof, SetupPolynomials, VerificationKey},
         commitments::transcript::keccak_transcript::RollingKeccakTranscript,
-        make_verification_key, prove, prove_by_steps, setup, transpile,
+        is_satisfied_using_one_shot_check, make_verification_key, prove, prove_by_steps, setup, transpile,
     },
     worker::Worker,
     Circuit, ScalarEngine, SynthesisError,
@@ -62,6 +62,7 @@ impl<E: Engine> SetupForProver<E> {
     }
 
     pub fn prove<C: Circuit<E> + Clone>(&self, circuit: C) -> Result<Proof<E, PlonkCsWidth4WithNextStepParams>, SynthesisError> {
+        is_satisfied_using_one_shot_check(circuit.clone(), &self.hints).expect("must satisfy");
         match &self.key_lagrange_form {
             Some(key_lagrange_form) => prove::<_, _, RollingKeccakTranscript<<E as ScalarEngine>::Fr>>(
                 circuit,


### PR DESCRIPTION
Fix <https://github.com/Fluidex/plonkit/issues/3>