### PR TITLE
Add prove server mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,6 +46,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
+name = "async-stream"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3670df70cbc01729f901f94c887814b3c68db038aad1329a418bae178bc5295c"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3548b8efc9f8e8a5a0a2808c5bd8451a9031b9e5b879a79590304ae928b0a70"
+dependencies = [
+ "proc-macro2 1.0.24",
+ "quote 1.0.9",
+ "syn 1.0.60",
+]
+
+[[package]]
+name = "async-trait"
+version = "0.1.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d3a45e77e34375a7923b1e8febb049bb011f064714a8e17a1a616fef01da13d"
+dependencies = [
+ "proc-macro2 1.0.24",
+ "quote 1.0.9",
+ "syn 1.0.60",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -76,6 +108,12 @@ checksum = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
 dependencies = [
  "byteorder",
 ]
+
+[[package]]
+name = "base64"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "bellman_ce"
@@ -174,6 +212,12 @@ name = "byteorder"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae44d1a3d5a19df61dd0c8beb138458ac2a53a7ac09eba97d55592540004306b"
+
+[[package]]
+name = "bytes"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
 
 [[package]]
 name = "cfg-if"
@@ -456,6 +500,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fixedbitset"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "fuchsia-cprng"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -517,6 +573,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28be053525281ad8259d47e4de5de657b25e7bac113458555bb4b70bc6870500"
 
 [[package]]
+name = "futures-macro"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c287d25add322d9f9abdcdc5927ca398917996600182178774032e9f8258fedd"
+dependencies = [
+ "proc-macro-hack",
+ "proc-macro2 1.0.24",
+ "quote 1.0.9",
+ "syn 1.0.60",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -540,11 +608,14 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-io",
+ "futures-macro",
  "futures-sink",
  "futures-task",
  "memchr",
  "pin-project-lite",
  "pin-utils",
+ "proc-macro-hack",
+ "proc-macro-nested",
  "slab 0.4.2",
 ]
 
@@ -555,6 +626,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
 dependencies = [
  "typenum",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "wasi",
+]
+
+[[package]]
+name = "h2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d832b01df74254fe364568d6ddc294443f61cbec82816b60904303af87efae78"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http",
+ "indexmap",
+ "slab 0.4.2",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -630,10 +731,67 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7245cd7449cc792608c3c8a9eaf69bd4eabbabf802713748fd739c98b82f0747"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2861bd27ee074e5ee891e8b539837a9430012e249d7f0ca2d795650f579c1994"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "httparse"
+version = "1.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "615caabe2c3160b313d52ccc905335f4ed5f10881dd63dc5699d47e90be85691"
+
+[[package]]
+name = "httpdate"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "494b4d60369511e7dea41cf646832512a94e542f68bb9c49e54518e0f468eb47"
+
+[[package]]
 name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
+name = "hyper"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8e946c2b1349055e0b72ae281b238baf1a3ea7307c7e9f9d64673bdd9c26ac7"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
 
 [[package]]
 name = "idna"
@@ -688,6 +846,15 @@ name = "itertools"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f56a2d0bc861f9165be4eb3442afd3c236d8a98afd426f65d92324ae1091a484"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
 dependencies = [
  "either",
 ]
@@ -775,10 +942,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "mio"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5dede4e2065b3842b8b0af444119f3aa331cc7cc2dd20388bfb0f5d5a38823a"
+dependencies = [
+ "libc",
+ "log",
+ "miow",
+ "ntapi",
+ "winapi",
+]
+
+[[package]]
+name = "miow"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a33c1b55807fbed163481b5ba66db4b2fa6cde694a5027be10fb724206c5897"
+dependencies = [
+ "socket2",
+ "winapi",
+]
+
+[[package]]
+name = "multimap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1255076139a83bb467426e7f8d0134968a8118844faa755985e077cf31850333"
+
+[[package]]
 name = "nodrop"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
+
+[[package]]
+name = "ntapi"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "num-bigint"
@@ -875,7 +1080,7 @@ dependencies = [
  "cloudabi",
  "libc",
  "rand 0.6.5",
- "redox_syscall",
+ "redox_syscall 0.1.57",
  "rustc_version",
  "smallvec",
  "winapi",
@@ -886,6 +1091,12 @@ name = "percent-encoding"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
+
+[[package]]
+name = "percent-encoding"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "pest"
@@ -931,6 +1142,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "petgraph"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "467d164a6de56270bd7c4d070df81d07beace25012d5103ced4e9ff08d6afdb7"
+dependencies = [
+ "fixedbitset",
+ "indexmap",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96fa8ebb90271c4477f144354485b8068bd8f6b78b428b01ba892ca26caf0b63"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "758669ae3558c6f74bd2a18b41f7ac0b5a195aea6639d6a9b5e5d1ad5ba24c0b"
+dependencies = [
+ "proc-macro2 1.0.24",
+ "quote 1.0.9",
+ "syn 1.0.60",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -954,15 +1195,26 @@ dependencies = [
  "clap-v3",
  "env_logger",
  "exitcode",
+ "futures 0.3.12",
  "hex-literal",
- "itertools",
+ "itertools 0.8.2",
  "log",
  "num-bigint",
  "num-traits",
+ "prost",
  "rand 0.4.6",
  "serde",
  "serde_json",
+ "tokio",
+ "tonic",
+ "tonic-build",
 ]
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
 
 [[package]]
 name = "primitive-types"
@@ -1010,6 +1262,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
+name = "proc-macro-nested"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
+
+[[package]]
 name = "proc-macro2"
 version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1025,6 +1283,57 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71"
 dependencies = [
  "unicode-xid 0.2.1",
+]
+
+[[package]]
+name = "prost"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e6984d2f1a23009bd270b8bb56d0926810a3d483f59c987d77969e9d8e840b2"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32d3ebd75ac2679c2af3a92246639f9fcc8a442ee420719cc4fe195b98dd5fa3"
+dependencies = [
+ "bytes",
+ "heck",
+ "itertools 0.9.0",
+ "log",
+ "multimap",
+ "petgraph",
+ "prost",
+ "prost-types",
+ "tempfile",
+ "which",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "169a15f3008ecb5160cba7d37bcd690a7601b6d30cfb87a117d45e59d52af5d4"
+dependencies = [
+ "anyhow",
+ "itertools 0.9.0",
+ "proc-macro2 1.0.24",
+ "quote 1.0.9",
+ "syn 1.0.60",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b518d7cdd93dab1d1122cf07fa9a60771836c668dde9d9e2a139f957f0d9f1bb"
+dependencies = [
+ "bytes",
+ "prost",
 ]
 
 [[package]]
@@ -1085,15 +1394,27 @@ checksum = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
 dependencies = [
  "autocfg 0.1.7",
  "libc",
- "rand_chacha",
+ "rand_chacha 0.1.1",
  "rand_core 0.4.2",
- "rand_hc",
+ "rand_hc 0.1.0",
  "rand_isaac",
  "rand_jitter",
  "rand_os",
  "rand_pcg",
  "rand_xorshift",
  "winapi",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ef9e7e66b4468674bfcb0c81af8b7fa0bb154fa9f28eb840da5c447baeb8d7e"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.0",
+ "rand_core 0.6.2",
+ "rand_hc 0.3.0",
 ]
 
 [[package]]
@@ -1104,6 +1425,16 @@ checksum = "556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef"
 dependencies = [
  "autocfg 0.1.7",
  "rand_core 0.3.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.2",
 ]
 
 [[package]]
@@ -1122,12 +1453,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
+name = "rand_core"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34cf66eb183df1c5876e2dcf6b13d57340741e8dc255b48e40a26de954d06ae7"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
 name = "rand_hc"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b40677c7be09ae76218dc623efbf7b18e34bced3f38883af07bb75630a21bc4"
 dependencies = [
  "rand_core 0.3.1",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
+dependencies = [
+ "rand_core 0.6.2",
 ]
 
 [[package]]
@@ -1199,6 +1548,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
 
 [[package]]
+name = "redox_syscall"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94341e4e44e24f6b591b59e47a8a027df12e008d73fd5672dbea9cc22f4507d9"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "regex"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1215,6 +1573,15 @@ name = "regex-syntax"
 version = "0.6.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5eb417147ba9860a96cfe72a0b93bf88fee1744b5636ec99ab20c1aa9376581"
+
+[[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "rlp"
@@ -1311,6 +1678,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16f1d0fef1604ba8f7a073c7e701f213e056707210e9020af4528e0101ce11a6"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "slab"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1329,6 +1705,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97fcaeba89edba30f044a10c6a3cc39df9c3f17d7cd829dd1446cab35f890e0"
 dependencies = [
  "maybe-uninit",
+]
+
+[[package]]
+name = "socket2"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "122e570113d28d773067fab24266b66753f6ea915758651696b6e35e49f88d6e"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -1377,6 +1764,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "rand 0.8.3",
+ "redox_syscall 0.2.5",
+ "remove_dir_all",
+ "winapi",
+]
+
+[[package]]
 name = "termcolor"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1392,6 +1793,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
  "unicode-width",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0f4a65597094d4483ddaed134f409b2cb7c1beccf25201a9f73c719254fa98e"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7765189610d8241a44529806d6fd1f2e0a08734313a35d5b3a556f92b381f3c0"
+dependencies = [
+ "proc-macro2 1.0.24",
+ "quote 1.0.9",
+ "syn 1.0.60",
 ]
 
 [[package]]
@@ -1428,6 +1849,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
+name = "tokio"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8190d04c665ea9e6b6a0dc45523ade572c088d2e6566244c1122671dbf4ae3a"
+dependencies = [
+ "autocfg 1.0.1",
+ "bytes",
+ "libc",
+ "memchr",
+ "mio",
+ "num_cpus",
+ "once_cell",
+ "pin-project-lite",
+ "signal-hook-registry",
+ "tokio-macros",
+ "winapi",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caf7b11a536f46a809a8a9f0bb4237020f70ecbf115b842360afb127ea2fda57"
+dependencies = [
+ "proc-macro2 1.0.24",
+ "quote 1.0.9",
+ "syn 1.0.60",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1981ad97df782ab506a1f43bf82c967326960d278acf3bf8279809648c3ff3ea"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-timer"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1436,6 +1898,142 @@ dependencies = [
  "futures 0.1.30",
  "slab 0.3.0",
 ]
+
+[[package]]
+name = "tokio-util"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebb7cb2f00c5ae8df755b252306272cd1790d39728363936e01827e11f0b017b"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "log",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tonic"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ba8f479158947373b6df40cf48f4779bb25c99ca3c661bd95e0ab1963ad8b0e"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "base64 0.13.0",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "percent-encoding 2.1.0",
+ "pin-project",
+ "prost",
+ "prost-derive",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tower",
+ "tower-service",
+ "tracing",
+ "tracing-futures",
+]
+
+[[package]]
+name = "tonic-build"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1e8546fd40d56d28089835c0a81bb396848103b00f888aea42d46eb5974df07"
+dependencies = [
+ "proc-macro2 1.0.24",
+ "prost-build",
+ "quote 1.0.9",
+ "syn 1.0.60",
+]
+
+[[package]]
+name = "tower"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f715efe02c0862926eb463e49368d38ddb119383475686178e32e26d15d06a66"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "indexmap",
+ "pin-project",
+ "rand 0.8.3",
+ "slab 0.4.2",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "343bc9466d3fe6b0f960ef45960509f84480bf4fd96f92901afe7ff3df9d3a62"
+
+[[package]]
+name = "tower-service"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
+
+[[package]]
+name = "tracing"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01ebdc2bb4498ab1ab5f5b73c5803825e60199229ccba0698170e3be0e7f959f"
+dependencies = [
+ "cfg-if 1.0.0",
+ "log",
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8a9bd1db7706f2373a190b0d067146caa39350c486f3d455b0e33b431f94c07"
+dependencies = [
+ "proc-macro2 1.0.24",
+ "quote 1.0.9",
+ "syn 1.0.60",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f50de3927f93d202783f4513cda820ab47ef17f624b03c096e86ef00c67e6b5f"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
+name = "tracing-futures"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
+dependencies = [
+ "pin-project",
+ "tracing",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
 name = "typenum"
@@ -1511,7 +2109,7 @@ checksum = "dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a"
 dependencies = [
  "idna",
  "matches",
- "percent-encoding",
+ "percent-encoding 1.0.1",
 ]
 
 [[package]]
@@ -1527,13 +2125,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
 
 [[package]]
+name = "want"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
+dependencies = [
+ "log",
+ "try-lock",
+]
+
+[[package]]
+name = "wasi"
+version = "0.10.2+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+
+[[package]]
 name = "web3"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "076f34ed252d74a8521e3b013254b1a39f94a98f23aae7cfc85cda6e7b395664"
 dependencies = [
  "arrayvec 0.4.12",
- "base64",
+ "base64 0.10.1",
  "derive_more",
  "ethabi",
  "ethereum-types",
@@ -1546,6 +2160,16 @@ dependencies = [
  "serde_json",
  "tokio-timer",
  "url",
+]
+
+[[package]]
+name = "which"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87c14ef7e1b8b8ecfc75d5eca37949410046e66f15d185c01d70824f1f8111ef"
+dependencies = [
+ "libc",
+ "thiserror",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,18 @@ bellman_vk_codegen = { git = "https://github.com/Fluidex/solidity_plonk_verifier
 anyhow = "1.0.34"
 log = "0.4.11"
 env_logger = "0.8.2"
+futures = "0.3"
+tonic = {version = "0.4.0", optional = true}
+prost = {version = "0.7.0", optional = true}
+tokio = {version = "*", features = ["rt-multi-thread", "signal", "sync"], optional = true}
+
+
+[build-dependencies]
+cfg-if = "1.0.0"
+tonic-build = "0.4.0"
 
 [features]
 default = ["bellman_ce/multicore", "solidity"]
 solidity = []
+server = ["tonic", "prost", "tokio"]
+windows_build = ["server"]

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,16 @@
+
+
+fn main() {
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "server")] {
+            tonic_build::configure()
+            .type_attribute(".", "#[derive(serde::Serialize, serde::Deserialize)]")
+            .compile(
+                &["server.proto"], 
+                &["."],
+            )
+            .unwrap();
+            println!("cargo:rerun-if-changed=server.proto");
+        }
+    }
+}

--- a/build.rs
+++ b/build.rs
@@ -1,12 +1,10 @@
-
-
 fn main() {
     cfg_if::cfg_if! {
         if #[cfg(feature = "server")] {
             tonic_build::configure()
             .type_attribute(".", "#[derive(serde::Serialize, serde::Deserialize)]")
             .compile(
-                &["server.proto"], 
+                &["server.proto"],
                 &["."],
             )
             .unwrap();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "plonkit",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/server.proto
+++ b/server.proto
@@ -1,0 +1,35 @@
+syntax = "proto3";
+
+package plonkitserver;
+
+service PlonkitServer {
+  rpc Prove(ProveRequest) returns (ProveResponse);
+  rpc ValidateWitness(ProveRequest) returns (ValidateResponse);
+  rpc Status(EmptyRequest) returns (StatusResponse);
+}
+
+message EmptyRequest {}
+
+message ProveRequest {
+  string task_name = 1;
+  bytes witness = 2;
+}
+
+message ProveResponse {
+  bool is_valid = 1;
+  string error_msg = 10;
+  double time_cost = 2;
+  repeated string proof = 3;
+  repeated string inputs = 4;
+}
+
+message ValidateResponse {
+  bool is_valid = 1;
+  string error_msg = 10;
+}
+
+message StatusResponse {
+  bool avaliable = 1;
+  string current_task_name = 2;
+}
+

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -88,6 +88,10 @@ pub fn load_witness_from_bin_file<E: Engine>(filename: &str) -> Vec<E::Fr> {
     load_witness_from_bin_reader::<E, BufReader<File>>(BufReader::new(reader)).expect("read witness failed")
 }
 
+pub fn load_witness_from_array<E: Engine>(buffer: Vec<u8>) -> Result<Vec<E::Fr>, anyhow::Error> {
+    load_witness_from_bin_reader::<E, _>(buffer.as_slice())
+}
+
 ///
 /// r1cs
 ///

--- a/src/server.rs
+++ b/src/server.rs
@@ -4,8 +4,8 @@
 #![allow(clippy::too_many_arguments)]
 #![allow(clippy::single_char_pattern)]
 
-use std::sync::Arc;
 use std::collections::VecDeque;
+use std::sync::Arc;
 use tokio::sync::{mpsc, oneshot, Mutex};
 
 pub mod pb {
@@ -13,18 +13,15 @@ pub mod pb {
 }
 
 #[derive(Clone, PartialEq)]
-pub enum CoreResult
-{
+pub enum CoreResult {
     Prove(pb::ProveResponse),
     Validate(pb::ValidateResponse),
 }
 
 impl CoreResult {
-
-    pub fn as_prove(self) -> pb::ProveResponse {
-
+    pub fn into_prove(self) -> pb::ProveResponse {
         match self {
-            Self::Validate(ret) => pb::ProveResponse{
+            Self::Validate(ret) => pb::ProveResponse {
                 is_valid: ret.is_valid,
                 error_msg: ret.error_msg,
                 time_cost: 0.0,
@@ -37,32 +34,33 @@ impl CoreResult {
 
     pub fn success(validate_only: bool) -> Self {
         if validate_only {
-            Self::Validate(pb::ValidateResponse{
+            Self::Validate(pb::ValidateResponse {
                 is_valid: true,
                 error_msg: String::new(),
             })
-        }else{
-            Self::Prove(pb::ProveResponse{
+        } else {
+            Self::Prove(pb::ProveResponse {
                 is_valid: true,
                 error_msg: String::new(),
                 time_cost: 0.0,
                 proof: Vec::new(),
                 inputs: Vec::new(),
             })
-        }        
+        }
     }
 
     pub fn any_prove_error<T, E>(err_ret: Result<T, E>, validate_only: bool) -> Self
-    where T : std::fmt::Debug,
+    where
+        T: std::fmt::Debug,
         E: std::fmt::Display,
     {
         if validate_only {
-            Self::Validate(pb::ValidateResponse{
+            Self::Validate(pb::ValidateResponse {
                 is_valid: false,
                 error_msg: format!("{}", err_ret.unwrap_err()),
             })
-        }else{
-            Self::Prove(pb::ProveResponse{
+        } else {
+            Self::Prove(pb::ProveResponse {
                 is_valid: false,
                 error_msg: format!("{}", err_ret.unwrap_err()),
                 time_cost: 0.0,
@@ -71,7 +69,6 @@ impl CoreResult {
             })
         }
     }
-
 }
 
 type ProveResultNotify = oneshot::Sender<CoreResult>;
@@ -79,8 +76,8 @@ type ProveRequest = (pb::ProveRequest, bool, ProveResultNotify);
 pub type ProveCore = Box<dyn Fn(Vec<u8>, bool) -> CoreResult + Send>;
 
 pub struct ServerOptions {
-    pub server_addr : Option<String>,
-    pub build_prove_core : Box<dyn FnOnce() -> ProveCore + Send>,
+    pub server_addr: Option<String>,
+    pub build_prove_core: Box<dyn FnOnce() -> ProveCore + Send>,
 }
 
 struct GrpcHandler {
@@ -90,8 +87,7 @@ struct GrpcHandler {
 }
 
 impl ServerOptions {
-    fn build_server(&self, prove_send: mpsc::Sender<ProveRequest>) -> GrpcHandler
-    {
+    fn build_server(&self, prove_send: mpsc::Sender<ProveRequest>) -> GrpcHandler {
         GrpcHandler {
             prove_tasks: Arc::new(Mutex::new(VecDeque::with_capacity(32))),
             cur_task: Arc::new(Mutex::new(None)),
@@ -100,12 +96,13 @@ impl ServerOptions {
     }
 }
 
-async fn schedule_prove_task(mut notify: mpsc::Receiver<ProveRequest>, 
+async fn schedule_prove_task(
+    mut notify: mpsc::Receiver<ProveRequest>,
     tasks: Arc<Mutex<VecDeque<ProveRequest>>>,
     cur_task_name: Arc<Mutex<Option<String>>>,
-    core_build: Box<dyn FnOnce() -> ProveCore + Send>)
-{
-    let mut prove_task_h = tokio::task::spawn_blocking(move||{
+    core_build: Box<dyn FnOnce() -> ProveCore + Send>,
+) {
+    let mut prove_task_h = tokio::task::spawn_blocking(move || {
         log::info!("Building proving core ...");
         let core = core_build();
         log::info!("Building proving core done");
@@ -113,17 +110,18 @@ async fn schedule_prove_task(mut notify: mpsc::Receiver<ProveRequest>,
     });
 
     loop {
-        let is_task_active = cur_task_name.lock().await.is_some();
+        let is_task_active = cur_task_name.lock().await.is_some() || !tasks.lock().await.is_empty();
 
         tokio::select! {
             h_ret = &mut prove_task_h, if is_task_active => {
-    
+
                 //if joinerror, we are over
                 let core = h_ret.unwrap();
-    
+
                 let last = match tasks.lock().await.pop_back() {
                     Some((req, valid_only, notify)) => {
                         let last_cur = cur_task_name.lock().await.replace(req.task_name.clone());
+                        log::debug!("Trigger handling new task {}", req.task_name);
 
                         //DO prove/valid task
                         prove_task_h = tokio::task::spawn_blocking(move||{
@@ -132,7 +130,7 @@ async fn schedule_prove_task(mut notify: mpsc::Receiver<ProveRequest>,
                             }
                             core
                         });
-    
+
                         last_cur
                     },
                     _ => {
@@ -141,12 +139,13 @@ async fn schedule_prove_task(mut notify: mpsc::Receiver<ProveRequest>,
                         cur_task_name.lock().await.take()
                     }
                 };
-    
+
                 if let Some(task_name) = last {
                     log::info!("Task {} is proven", task_name);
                 }
             }
             Some(newtask) = notify.recv() => {
+                log::debug!("Receive new task {}", newtask.0.task_name);
                 tasks.lock().await.push_front(newtask);
             }
             else => {
@@ -157,105 +156,80 @@ async fn schedule_prove_task(mut notify: mpsc::Receiver<ProveRequest>,
     }
 }
 
-
 use pb::plonkit_server_server::{PlonkitServer, PlonkitServerServer};
 
 #[tonic::async_trait]
 impl PlonkitServer for GrpcHandler {
-
-    async fn prove(&self, request: tonic::Request<pb::ProveRequest>) 
-    -> Result<tonic::Response<pb::ProveResponse>, tonic::Status>
-    {
+    async fn prove(&self, request: tonic::Request<pb::ProveRequest>) -> Result<tonic::Response<pb::ProveResponse>, tonic::Status> {
         let (tx, rx) = oneshot::channel();
-        if let Err(e) = self.prove_send.send((request.into_inner(), false, tx)).await
-        {
+        if let Err(e) = self.prove_send.send((request.into_inner(), false, tx)).await {
             return Err(tonic::Status::internal(format!("send prove request fail: {}", e)));
         }
 
-        match rx.await{
-            Ok(CoreResult::Prove(ret)) => {
-                Ok(tonic::Response::new(ret))
-            },
-            Ok(_) => {
-                Err(tonic::Status::internal("prove core return unmatched ret type"))
-            },
-            Err(e) => {
-                Err(tonic::Status::internal(format!("recv prove response fail: {}", e)))
-            }
+        match rx.await {
+            Ok(CoreResult::Prove(ret)) => Ok(tonic::Response::new(ret)),
+            Ok(_) => Err(tonic::Status::internal("prove core return unmatched ret type")),
+            Err(e) => Err(tonic::Status::internal(format!("recv prove response fail: {}", e))),
         }
     }
     async fn validate_witness(
         &self,
         request: tonic::Request<pb::ProveRequest>,
-    ) -> Result<tonic::Response<pb::ValidateResponse>, tonic::Status>
-    {
+    ) -> Result<tonic::Response<pb::ValidateResponse>, tonic::Status> {
         let (tx, rx) = oneshot::channel();
-        if let Err(e) = self.prove_send.send((request.into_inner(), true, tx)).await
-        {
+        if let Err(e) = self.prove_send.send((request.into_inner(), true, tx)).await {
             return Err(tonic::Status::internal(format!("send prove request fail: {}", e)));
         }
 
-        match rx.await{
-            Ok(CoreResult::Validate(ret)) => {
-                Ok(tonic::Response::new(ret))
-            },
-            Ok(_) => {
-                Err(tonic::Status::internal("prove core return unmatched ret type"))
-            },
-            Err(e) => {
-                Err(tonic::Status::internal(format!("recv prove response fail: {}", e)))
-            }
+        match rx.await {
+            Ok(CoreResult::Validate(ret)) => Ok(tonic::Response::new(ret)),
+            Ok(_) => Err(tonic::Status::internal("prove core return unmatched ret type")),
+            Err(e) => Err(tonic::Status::internal(format!("recv prove response fail: {}", e))),
         }
     }
-    async fn status(
-        &self,
-        _request: tonic::Request<pb::EmptyRequest>,
-    ) -> Result<tonic::Response<pb::StatusResponse>, tonic::Status>
-    {
+    async fn status(&self, _request: tonic::Request<pb::EmptyRequest>) -> Result<tonic::Response<pb::StatusResponse>, tonic::Status> {
         let cur = self.cur_task.lock().await;
         Ok(tonic::Response::new(pb::StatusResponse {
             avaliable: cur.is_none(),
-            current_task_name: cur.as_ref().map(String::clone)
-                .unwrap_or_else(String::new),
-        })) 
+            current_task_name: cur.as_ref().map(String::clone).unwrap_or_else(String::new),
+        }))
     }
 }
 
 use futures::future::TryFutureExt;
 
-pub fn run(opt : ServerOptions) {
+pub fn run(opt: ServerOptions) {
     env_logger::init();
 
     tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()
         .expect("build runtime")
-        .block_on(
-            async move {
-                //just set a magic number because we always keep pumping request
-                let (tx, rx) = mpsc::channel(16);
-                let svr = opt.build_server(tx);
-                let addr = opt.server_addr.unwrap_or(String::from("0.0.0.0:50055"));
-                let buildcore = opt.build_prove_core;
-                log::info!("Starting grpc server at {}", addr);
+        .block_on(async move {
+            //just set a magic number because we always keep pumping request
+            let (tx, rx) = mpsc::channel(16);
+            let svr = opt.build_server(tx);
+            let addr = opt.server_addr.unwrap_or_else(|| String::from("0.0.0.0:50055"));
+            let buildcore = opt.build_prove_core;
+            log::info!("Starting grpc server at {}", addr);
 
-                let tasks_scheduled = svr.prove_tasks.clone();
-                let status_scheduled = svr.cur_task.clone();
-                let scheduler = tokio::spawn(async move {
-                    schedule_prove_task(rx, tasks_scheduled, 
-                        status_scheduled, buildcore).await;
-                });
+            let tasks_scheduled = svr.prove_tasks.clone();
+            let status_scheduled = svr.cur_task.clone();
+            let scheduler = tokio::spawn(async move {
+                schedule_prove_task(rx, tasks_scheduled, status_scheduled, buildcore).await;
+            });
 
-                tonic::transport::Server::builder()
+            tonic::transport::Server::builder()
                 .add_service(PlonkitServerServer::new(svr))
-                .serve_with_shutdown(addr.parse().unwrap(), 
-                    tokio::signal::ctrl_c().unwrap_or_else(|_|{
-                        panic!("failed to listen for event")
-                    })).await.unwrap();
-                log::info!("Server shutted down");
-                scheduler.await.unwrap();
-            }
-        );
+                .serve_with_shutdown(
+                    addr.parse().unwrap(),
+                    tokio::signal::ctrl_c().unwrap_or_else(|_| panic!("failed to listen for event")),
+                )
+                .await
+                .unwrap();
+            log::info!("Server shutted down");
+            scheduler.await.unwrap();
+        });
 
     log::info!("Running finish");
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,0 +1,261 @@
+#![allow(dead_code)]
+#![allow(clippy::collapsible_if)]
+#![allow(clippy::let_and_return)]
+#![allow(clippy::too_many_arguments)]
+#![allow(clippy::single_char_pattern)]
+
+use std::sync::Arc;
+use std::collections::VecDeque;
+use tokio::sync::{mpsc, oneshot, Mutex};
+
+pub mod pb {
+    tonic::include_proto!("plonkitserver");
+}
+
+#[derive(Clone, PartialEq)]
+pub enum CoreResult
+{
+    Prove(pb::ProveResponse),
+    Validate(pb::ValidateResponse),
+}
+
+impl CoreResult {
+
+    pub fn as_prove(self) -> pb::ProveResponse {
+
+        match self {
+            Self::Validate(ret) => pb::ProveResponse{
+                is_valid: ret.is_valid,
+                error_msg: ret.error_msg,
+                time_cost: 0.0,
+                proof: Vec::new(),
+                inputs: Vec::new(),
+            },
+            Self::Prove(ret) => ret,
+        }
+    }
+
+    pub fn success(validate_only: bool) -> Self {
+        if validate_only {
+            Self::Validate(pb::ValidateResponse{
+                is_valid: true,
+                error_msg: String::new(),
+            })
+        }else{
+            Self::Prove(pb::ProveResponse{
+                is_valid: true,
+                error_msg: String::new(),
+                time_cost: 0.0,
+                proof: Vec::new(),
+                inputs: Vec::new(),
+            })
+        }        
+    }
+
+    pub fn any_prove_error<T, E>(err_ret: Result<T, E>, validate_only: bool) -> Self
+    where T : std::fmt::Debug,
+        E: std::fmt::Display,
+    {
+        if validate_only {
+            Self::Validate(pb::ValidateResponse{
+                is_valid: false,
+                error_msg: format!("{}", err_ret.unwrap_err()),
+            })
+        }else{
+            Self::Prove(pb::ProveResponse{
+                is_valid: false,
+                error_msg: format!("{}", err_ret.unwrap_err()),
+                time_cost: 0.0,
+                proof: Vec::new(),
+                inputs: Vec::new(),
+            })
+        }
+    }
+
+}
+
+type ProveResultNotify = oneshot::Sender<CoreResult>;
+type ProveRequest = (pb::ProveRequest, bool, ProveResultNotify);
+pub type ProveCore = Box<dyn Fn(Vec<u8>, bool) -> CoreResult + Send>;
+
+pub struct ServerOptions {
+    pub server_addr : Option<String>,
+    pub build_prove_core : Box<dyn FnOnce() -> ProveCore + Send>,
+}
+
+struct GrpcHandler {
+    prove_tasks: Arc<Mutex<VecDeque<ProveRequest>>>,
+    cur_task: Arc<Mutex<Option<String>>>,
+    prove_send: mpsc::Sender<ProveRequest>,
+}
+
+impl ServerOptions {
+    fn build_server(&self, prove_send: mpsc::Sender<ProveRequest>) -> GrpcHandler
+    {
+        GrpcHandler {
+            prove_tasks: Arc::new(Mutex::new(VecDeque::with_capacity(32))),
+            cur_task: Arc::new(Mutex::new(None)),
+            prove_send,
+        }
+    }
+}
+
+async fn schedule_prove_task(mut notify: mpsc::Receiver<ProveRequest>, 
+    tasks: Arc<Mutex<VecDeque<ProveRequest>>>,
+    cur_task_name: Arc<Mutex<Option<String>>>,
+    core_build: Box<dyn FnOnce() -> ProveCore + Send>)
+{
+    let mut prove_task_h = tokio::task::spawn_blocking(move||{
+        log::info!("Building proving core ...");
+        let core = core_build();
+        log::info!("Building proving core done");
+        core
+    });
+
+    loop {
+        let is_task_active = cur_task_name.lock().await.is_some();
+
+        tokio::select! {
+            h_ret = &mut prove_task_h, if is_task_active => {
+    
+                //if joinerror, we are over
+                let core = h_ret.unwrap();
+    
+                let last = match tasks.lock().await.pop_back() {
+                    Some((req, valid_only, notify)) => {
+                        let last_cur = cur_task_name.lock().await.replace(req.task_name.clone());
+
+                        //DO prove/valid task
+                        prove_task_h = tokio::task::spawn_blocking(move||{
+                            if notify.send(core(req.witness, valid_only)).is_err(){
+                                log::warn!("Send task {} result failure", req.task_name);
+                            }
+                            core
+                        });
+    
+                        last_cur
+                    },
+                    _ => {
+                        //put the core into joinhandle ("The Sword in the Stone")
+                        prove_task_h = tokio::task::spawn_blocking(move||{core});
+                        cur_task_name.lock().await.take()
+                    }
+                };
+    
+                if let Some(task_name) = last {
+                    log::info!("Task {} is proven", task_name);
+                }
+            }
+            Some(newtask) = notify.recv() => {
+                tasks.lock().await.push_front(newtask);
+            }
+            else => {
+                //everything is over (receiver is closed and no active task), we just leave
+                return;
+            }
+        }
+    }
+}
+
+
+use pb::plonkit_server_server::{PlonkitServer, PlonkitServerServer};
+
+#[tonic::async_trait]
+impl PlonkitServer for GrpcHandler {
+
+    async fn prove(&self, request: tonic::Request<pb::ProveRequest>) 
+    -> Result<tonic::Response<pb::ProveResponse>, tonic::Status>
+    {
+        let (tx, rx) = oneshot::channel();
+        if let Err(e) = self.prove_send.send((request.into_inner(), false, tx)).await
+        {
+            return Err(tonic::Status::internal(format!("send prove request fail: {}", e)));
+        }
+
+        match rx.await{
+            Ok(CoreResult::Prove(ret)) => {
+                Ok(tonic::Response::new(ret))
+            },
+            Ok(_) => {
+                Err(tonic::Status::internal("prove core return unmatched ret type"))
+            },
+            Err(e) => {
+                Err(tonic::Status::internal(format!("recv prove response fail: {}", e)))
+            }
+        }
+    }
+    async fn validate_witness(
+        &self,
+        request: tonic::Request<pb::ProveRequest>,
+    ) -> Result<tonic::Response<pb::ValidateResponse>, tonic::Status>
+    {
+        let (tx, rx) = oneshot::channel();
+        if let Err(e) = self.prove_send.send((request.into_inner(), true, tx)).await
+        {
+            return Err(tonic::Status::internal(format!("send prove request fail: {}", e)));
+        }
+
+        match rx.await{
+            Ok(CoreResult::Validate(ret)) => {
+                Ok(tonic::Response::new(ret))
+            },
+            Ok(_) => {
+                Err(tonic::Status::internal("prove core return unmatched ret type"))
+            },
+            Err(e) => {
+                Err(tonic::Status::internal(format!("recv prove response fail: {}", e)))
+            }
+        }
+    }
+    async fn status(
+        &self,
+        _request: tonic::Request<pb::EmptyRequest>,
+    ) -> Result<tonic::Response<pb::StatusResponse>, tonic::Status>
+    {
+        let cur = self.cur_task.lock().await;
+        Ok(tonic::Response::new(pb::StatusResponse {
+            avaliable: cur.is_none(),
+            current_task_name: cur.as_ref().map(String::clone)
+                .unwrap_or_else(String::new),
+        })) 
+    }
+}
+
+use futures::future::TryFutureExt;
+
+pub fn run(opt : ServerOptions) {
+    env_logger::init();
+
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .expect("build runtime")
+        .block_on(
+            async move {
+                //just set a magic number because we always keep pumping request
+                let (tx, rx) = mpsc::channel(16);
+                let svr = opt.build_server(tx);
+                let addr = opt.server_addr.unwrap_or(String::from("0.0.0.0:50055"));
+                let buildcore = opt.build_prove_core;
+                log::info!("Starting grpc server at {}", addr);
+
+                let tasks_scheduled = svr.prove_tasks.clone();
+                let status_scheduled = svr.cur_task.clone();
+                let scheduler = tokio::spawn(async move {
+                    schedule_prove_task(rx, tasks_scheduled, 
+                        status_scheduled, buildcore).await;
+                });
+
+                tonic::transport::Server::builder()
+                .add_service(PlonkitServerServer::new(svr))
+                .serve_with_shutdown(addr.parse().unwrap(), 
+                    tokio::signal::ctrl_c().unwrap_or_else(|_|{
+                        panic!("failed to listen for event")
+                    })).await.unwrap();
+                log::info!("Server shutted down");
+                scheduler.await.unwrap();
+            }
+        );
+
+    log::info!("Running finish");
+}

--- a/testdata/package.json
+++ b/testdata/package.json
@@ -5,7 +5,10 @@
     "chai": "^4.3.0",
     "ethereum-waffle": "^3.2.2",
     "ethers": "^5.0.31",
-    "hardhat": "^2.0.10"
+    "hardhat": "^2.0.10",
+    "dotenv": "^8.2.0",
+    "grpc": "^1.24.2",
+    "grpc-caller": "^0.13.0"
   },
   "dependencies": {
     "@nomiclabs/buidler": "^1.4.8"

--- a/testdata/test/plonk-server.mjs
+++ b/testdata/test/plonk-server.mjs
@@ -1,0 +1,30 @@
+import * as fs from 'fs';
+import caller from "grpc-caller";
+const file = "../server.proto";
+const load = {
+  keepCase: true,
+  longs: String,
+  defaults: false,
+};
+const server = process.env.GRPC_SERVER || "localhost:50055";
+console.log("using grpc", server);
+const client = caller(`${server}`, { file, load }, "PlonkitServer");
+
+var task_cnt = 0
+
+export async function prove(witness_fn) {
+
+  const result = (await client.Prove({ 
+    task_name: `task ${task_cnt}`,
+    witness: fs.readFileSync(witness_fn || 'witness.wtns'),
+  }));
+
+  task_cnt = task_cnt + 1;
+
+  return result;
+}
+
+
+export async function status() {
+  return await client.Status({});
+}


### PR DESCRIPTION
An implement for the server mode according to #19, also:

+ Add dependencies for server: tokio/tonic/tonic-build and the "server" feature

+ Add build script for the protobuf definition

+ Script for integration test

*P.S: there seems to be too many println which output to console for a server, should we remove some of them later?*