### PR TITLE
fix(server mode): use instant for time measurement

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -281,10 +281,10 @@ fn prove_server(opts: ServerOpts) {
                     err => return server::CoreResult::any_prove_error(err, validate_only),
                 }
             } else {
-                let perf_t = std::time::SystemTime::now();
+                let start = std::time::Instant::now();
                 match setup.prove(circut) {
                     Ok(proof) => {
-                        let elapsed = perf_t.elapsed().unwrap_or_default().as_secs_f64();
+                        let elapsed = start.elapsed().as_secs_f64();
 
                         let ret = server::CoreResult::success(validate_only);
                         let mut mut_resp = ret.into_prove();


### PR DESCRIPTION
according to https://doc.rust-lang.org/std/time/struct.SystemTime.html

> A measurement of the system clock, useful for talking to external entities like the file system or other processes.
Distinct from the Instant type, this time measurement is not monotonic. This means that you can save a file to the file system, then save another file to the file system, and the second file has a SystemTime measurement earlier than the first. In other words, an operation that happens after another operation in real time may have an earlier SystemTime!
Consequently, comparing two SystemTime instances to learn about the duration between them returns a Result instead of an infallible Duration to indicate that this sort of time drift may happen and needs to be handled.

bellman_ce also uses `Instant`
