### PR TITLE
rename time_cost to time_cost_secs

### DIFF
--- a/server.proto
+++ b/server.proto
@@ -18,7 +18,7 @@ message ProveRequest {
 message ProveResponse {
   bool is_valid = 1;
   string error_msg = 10;
-  double time_cost = 2;
+  double time_cost_secs = 2;
   repeated string proof = 3;
   repeated string inputs = 4;
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -292,7 +292,7 @@ fn prove_server(opts: ServerOpts) {
                         let (inputs, serialized_proof) = bellman_vk_codegen::serialize_proof(&proof);
                         mut_resp.proof = serialized_proof.iter().map(ToString::to_string).collect();
                         mut_resp.inputs = inputs.iter().map(ToString::to_string).collect();
-                        mut_resp.time_cost = elapsed;
+                        mut_resp.time_cost_secs = elapsed;
 
                         return server::CoreResult::Prove(mut_resp);
                     }

--- a/src/server.rs
+++ b/src/server.rs
@@ -24,7 +24,7 @@ impl CoreResult {
             Self::Validate(ret) => pb::ProveResponse {
                 is_valid: ret.is_valid,
                 error_msg: ret.error_msg,
-                time_cost: 0.0,
+                time_cost_secs: 0.0,
                 proof: Vec::new(),
                 inputs: Vec::new(),
             },
@@ -41,7 +41,7 @@ impl CoreResult {
             false => Self::Prove(pb::ProveResponse {
                 is_valid: true,
                 error_msg: String::new(),
-                time_cost: 0.0,
+                time_cost_secs: 0.0,
                 proof: Vec::new(),
                 inputs: Vec::new(),
             }),
@@ -61,7 +61,7 @@ impl CoreResult {
             false => Self::Prove(pb::ProveResponse {
                 is_valid: false,
                 error_msg: format!("{}", err_ret.unwrap_err()),
-                time_cost: 0.0,
+                time_cost_secs: 0.0,
                 proof: Vec::new(),
                 inputs: Vec::new(),
             }),


### PR DESCRIPTION
We need to make API well-defined and more understandable.

bellman_ce uses `duration_ns`
`Struct std::time::Duration` has functions like `as_secs_f64`, `as_secs`, `as_nanos` ...

I think we can use `time_cost_secs`
