### PR TITLE
unwrap_or -> unwrap_or_else

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -219,7 +219,7 @@ fn analyse(opts: AnalyseOpts) {
     stats.constraint_stats.clear();
     log::info!(
         "analyse result: {}",
-        serde_json::to_string_pretty(&stats).unwrap_or("<failed>".to_owned())
+        serde_json::to_string_pretty(&stats).unwrap_or_else(|_| "<failed>".to_owned())
     );
     log::info!("output to {}", opts.output);
 }


### PR DESCRIPTION
https://stackoverflow.com/questions/45547293/why-should-i-prefer-optionok-or-else-instead-of-optionok-or

unwrap_or_else can avoid side effects and improve performance.